### PR TITLE
changed contact directory during import to uppercase to fix deploy error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import api from './api';
 import Profile from './Profile';
 import Registration from './Registration';
 import Product from './Product';
-import Contact from './contact';
+import Contact from './Contact';
 
 
 const App = ()=> {


### PR DESCRIPTION
- Changed "import Contact from './contact';" to "import Contact from './Contact';"
- Contact was made uppercase due to case sensitivity during deployment